### PR TITLE
Ignore slackbot by default and allow ignoring more users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Then, define the following attributes:
 * `webhook_token` (String) – Slack integration token.
 * `team_domain` (String) – Slack team domain; subdomain of slack.com.
 
+### Optional attributes
+* `ignore_user_name` - Either a string with a single user name, or an array of strings. - Messages from these users will be ignored by lita-slack-handler. The _slackbot_ user is ignored by default in order to prevent chat loops and does not need to be listed here.
+
 ### Example lita_config.rb
 
 ``` ruby

--- a/lib/lita/handlers/slack_handler.rb
+++ b/lib/lita/handlers/slack_handler.rb
@@ -76,11 +76,15 @@ module Lita
 
 			def ignore?(req)
 				ignore = false
-				if !config.ignore_user_name.nil? && req['user_name'].eql?(config.ignore_user_name)
+				if ignored_users.include?(req['user_name'])
 					log.warn "SlackHandler: #{req['user_name']} matches ignore_user_name #{config.ignore_user_name}"
 					ignore = true
 				end
 				return ignore
+			end
+
+			def ignored_users
+			  ['slackbot', config.ignore_user_name].flatten.compact
 			end
 
 			#

--- a/spec/lita/handlers/slack_handler_spec.rb
+++ b/spec/lita/handlers/slack_handler_spec.rb
@@ -61,6 +61,14 @@ describe Lita::Handlers::SlackHandler, lita_handler: true do
 				req['user_name'] = 'slackbot'
 				expect(subject.ignore?(req)).to eql(true)
 			end
+
+			it 'returns true when ignore_user_name is an array and contains the user_name' do
+				Lita.config.handlers.slack_handler.ignore_user_name = ["lita", "another_bot", "final_bot"]
+				req['token'] = Lita.config.handlers.slack_handler.webhook_token
+				req['team_domain'] = Lita.config.handlers.slack_handler.team_domain
+				req['user_name'] = 'another_bot'
+				expect(subject.ignore?(req)).to eql(true)
+			end
 		end
 	end
 

--- a/spec/lita/handlers/slack_handler_spec.rb
+++ b/spec/lita/handlers/slack_handler_spec.rb
@@ -54,6 +54,13 @@ describe Lita::Handlers::SlackHandler, lita_handler: true do
 				req['user_name'] = 'lita'
 				expect(subject.ignore?(req)).to eql(true)
 			end
+
+			it 'returns true for messages posted by slackbot' do
+				req['token'] = Lita.config.handlers.slack_handler.webhook_token
+				req['team_domain'] = Lita.config.handlers.slack_handler.team_domain
+				req['user_name'] = 'slackbot'
+				expect(subject.ignore?(req)).to eql(true)
+			end
 		end
 	end
 


### PR DESCRIPTION
This is intended to fix #1 . While implementing the fix, we realized we could support specifying multiple users to ignore in the lita config, so we added that as well.
