### PR TITLE
Allow running in lita 4 series

### DIFF
--- a/lita-slack-handler.gemspec
+++ b/lita-slack-handler.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 3.0"
+  spec.add_runtime_dependency "lita", ">= 3.0", "< 5"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This is working for @leejones and I. [Lita 4](http://docs.lita.io/releases/4/) is fully backwards-compatible. It does deprecate some features, but they [won't be removed](http://docs.lita.io/getting-started/versioning-policy/) until Lita 5.
